### PR TITLE
Add Novoda's bintray release plugin

### DIFF
--- a/app/src/main/java/com/github/charbgr/litho_picasso_component_sample/lithography/PicassoSingleImageComponentSpec.java
+++ b/app/src/main/java/com/github/charbgr/litho_picasso_component_sample/lithography/PicassoSingleImageComponentSpec.java
@@ -6,7 +6,7 @@ import com.facebook.litho.annotations.LayoutSpec;
 import com.facebook.litho.annotations.OnCreateLayout;
 import com.facebook.litho.annotations.Prop;
 import com.facebook.litho.annotations.PropDefault;
-import com.github.charbgr.litho.picasso.PicassoImage;
+import com.github.charbgr.litho.picassox.PicassoImage;
 
 @LayoutSpec
 public class PicassoSingleImageComponentSpec {

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,13 @@ buildscript {
                   'soloader'   : '0.5.1',
                   'androidAnnotation' : '1.0.2',
                   'androidAppCompat' : '1.0.2',
-                  'androidRecyclerver' : '1.0.0',
+                  'androidRecyclerview' : '1.0.0',
 
   ]
 
   dependencies {
     classpath 'com.android.tools.build:gradle:3.4.1'
+    classpath 'com.novoda:bintray-release:0.9.1'
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,25 +12,3 @@
 org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX = true
 android.enableJetifier = true
-
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-VERSION_NAME=1.0
-VERSION_CODE=1
-GROUP=com.github.charbgr
-
-POM_DESCRIPTION=Picasso image loading Component for Litho
-POM_URL=https://github.com/charbgr/litho-picasso
-POM_SCM_URL=https://github.com/charbgr/litho-picasso
-POM_SCM_CONNECTION=scm:git@github.com:charbgr/litho-picasso.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:charbgr/litho-picasso.git
-POM_LICENCE_NAME=MIT License
-POM_LICENCE_URL=https://opensource.org/licenses/MIT
-POM_LICENCE_DIST=repo
-POM_ARTIFACT_ID=litho-picasso
-POM_NAME=litho-picasso
-POM_PACKAGING=aar
-POM_DEVELOPER_ID=charbgr
-POM_DEVELOPER_NAME=Vasilis Charalampakis

--- a/litho-picasso/build.gradle
+++ b/litho-picasso/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.novoda.bintray-release'
 
 android {
   compileSdkVersion rootProject.ext.versions.compile_sdk
@@ -11,8 +12,6 @@ android {
   }
 }
 
-tasks.withType(Javadoc).all { enabled = false }
-
 dependencies {
 
   implementation "com.facebook.litho:litho-annotations:${versions.litho}"
@@ -24,12 +23,14 @@ dependencies {
   annotationProcessor "com.facebook.litho:litho-processor:${versions.litho}"
 }
 
-ext {
-  PUBLISH_GROUP_ID = 'com.github.charbgr'
-  PUBLISH_ARTIFACT_ID = 'litho-picasso'
-  PUBLISH_VERSION = '1.0'
+publish {
+  userOrg = 'bmpak04'
+  groupId = 'com.github.charbgr'
+  artifactId = 'litho-picassox'
+  repoName = 'charbgr'
+  uploadName = 'Litho_PicassoX'
+  publishVersion = '1.0'
+  desc = 'Picasso image loading Component for Litho'
+  website = 'https://github.com/charbgr/litho-picasso'
+  autoPublish = true
 }
-
-//apply from: 'https://raw.githubusercontent.com/ArthurHub/release-android-library/master/android-release-aar.gradle'
-
-//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/litho-picasso/src/main/AndroidManifest.xml
+++ b/litho-picasso/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.charbgr.litho.picasso">
+    package="com.github.charbgr.litho.picassox">
 </manifest>

--- a/litho-picasso/src/main/java/com/github/charbgr/litho/picassox/PicassoImageSpec.java
+++ b/litho-picasso/src/main/java/com/github/charbgr/litho/picassox/PicassoImageSpec.java
@@ -1,4 +1,4 @@
-package com.github.charbgr.litho.picasso;
+package com.github.charbgr.litho.picassox;
 
 import android.content.Context;
 import android.graphics.Bitmap;


### PR DESCRIPTION
This will provide an ease when publishing artifacts at jCenter. I don't think there is a project without jcenter repository thats why I don't publish Maven atm. 

I could use the official bintray-release plugin but novoda's worked like a charm with the first try!

